### PR TITLE
Automatically install plugin dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 images/*
 LICENSE
 README.md
+test/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Intel CPUs with an iGPU can utilise full hardware transcoding (decode and encode
 
 ![intel transcode example](images/intel_transcode.png)
 
+### How To Install Plugin Dependencies Automatically
+*Note: Your plugin must have a requirements file for this to work*
+
+1. Install plugins through the stash interface or manually
+2. Restart the container
+3. Dependencies will be parsed and installed for all plugins in the stash plugin folder
+4. Profit?!
+
 ### docker-compose
 
 You must modify the below compose file to pass your GPU through to the docker container. See this helpful guide from Jellyfin for more info. https://jellyfin.org/docs/general/administration/hardware-acceleration/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,18 +1,48 @@
 #!/bin/bash
-echo '───────────────────────────────────────
+
+# Path to the config file
+config_file="/root/.stash/config.yml"
+
+# Extract the plugins_path from the config file
+plugins_path=$(grep -E '^plugins_path:' "$config_file" | sed 's/plugins_path:[ ]*//')
+
+# Check if plugins_path was found
+if [ -z "$plugins_path" ]; then
+    echo "Warning: plugins_path not found in $config_file"
+    echo "Skipping python modules installation"
+else
+    # Initialize an empty variable to store the contents
+    all_requirements=""
+
+    # Find all requirements.txt files and process them
+    while IFS= read -r -d '' file; do
+        # Append the contents of the file to the variable
+        all_requirements+="$(cat "$file")"$'\n'
+    done < <(find "$plugins_path" -type f -name "requirements.txt" -print0)
+
+    # Deduplicate the requirements
+    unique_requirements=$(echo "$all_requirements" | sort | uniq)
+
+    # Define the output file path
+    output_file="$plugins_path/requirements.txt"
+
+    # Ensure the output directory exists
+    mkdir -p "$(dirname "$output_file")"
+
+    # Write the unique requirements to the output file
+    echo "$unique_requirements" >"$output_file"
+
+    echo "Deduplicated requirements have been saved to $output_file"
+    echo '───────────────────────────────────────
 
 Installing plugin dependencies...
 
 ───────────────────────────────────────
-'
-python3 -m venv ${PY_VENV}
-pip install \
-    bencoder.pyx \
-    cloudscraper \
-    lxml \
-    requests \
-    requests-toolbelt \
-    stashapp-tools
+    '
+    python3 -m venv ${PY_VENV}
+    pip install -r $plugins_path/requirements.txt
+fi
+
 gem install \
     faraday
 


### PR DESCRIPTION
This PR adds logic to the entrypoint script that parses the requirements file for each plugin, deduplicates the output and then installs the modules. If new plugins are installed then the container will need to be restarted for the dependencies to be installed.

Closes #14 