### PR TITLE
Make PUID/PGID opt-in to fix regression for root-based setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ services:
 
 Ensure host permissions are correct for the mounted volumes.
 
+If you set `PUID`/`PGID`, they must match the UID/GID that owns the host bind mounts — otherwise the in-container `stash` user can't read/write its config and Stash fails with `permission denied` on `config.yml`. Typical host UIDs: TrueNAS Scale apps (568), Unraid (99), Synology (1024), most Linux desktops/servers (1000). The entrypoint warns at startup if PUID and the bind-mount owner don't line up.
+
 **GPU not detected**
 * NVIDIA: driver + runtime present? (`nvidia-smi` on host)
 * Intel/AMD: is `/dev/dri` mapped and readable?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -118,6 +118,15 @@ if [ -n "${PUID:-}" ] || [ -n "${PGID:-}" ]; then
     groupmod -o -g "$PGID" stash
     usermod -o -u "$PUID" stash
     echo "UID:${PUID} GID:${PGID}"
+
+    # Warn if PUID doesn't match the actual owner of the config dir
+    actual_uid=$(stat -c '%u' /root/.stash 2>/dev/null || echo "")
+    if [ -n "$actual_uid" ] && [ "$actual_uid" != "$PUID" ]; then
+        echo "Warning: /root/.stash is owned by UID ${actual_uid}, but PUID=${PUID}."
+        echo "Stash may fail with 'permission denied'. Either set PUID=${actual_uid} (and PGID to match),"
+        echo "or chown the host bind mount to ${PUID}:${PGID} before starting the container."
+    fi
+
     exec gosu stash "$@"
 fi
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,25 +108,21 @@ if [ -n "${PUID:-}" ] || [ -n "${PGID:-}" ]; then
         exit 1
     fi
     if ! [[ "$PUID" =~ ^[0-9]+$ ]] || ! [[ "$PGID" =~ ^[0-9]+$ ]]; then
-        echo "Error: PUID and PGID must be positive integers" >&2
+        echo "Error: PUID and PGID must be numeric" >&2
         exit 1
     fi
     if [ "$PUID" -eq 0 ] || [ "$PGID" -eq 0 ]; then
-        echo "Error: PUID/PGID cannot be 0" >&2
-        exit 1
+        exec "$@"
+    fi
+    actual_uid=$(stat -c '%u' /root/.stash 2>/dev/null || echo "")
+    if [ -n "$actual_uid" ] && [ "$actual_uid" != "$PUID" ]; then
+        echo "Warning: /root/.stash is owned by UID ${actual_uid} but PUID=${PUID} — running as root to avoid permission errors."
+        echo "To enable user switching, chown the config directory to ${PUID}:${PGID} on the host first."
+        exec "$@"
     fi
     groupmod -o -g "$PGID" stash
     usermod -o -u "$PUID" stash
     echo "UID:${PUID} GID:${PGID}"
-
-    # Warn if PUID doesn't match the actual owner of the config dir
-    actual_uid=$(stat -c '%u' /root/.stash 2>/dev/null || echo "")
-    if [ -n "$actual_uid" ] && [ "$actual_uid" != "$PUID" ]; then
-        echo "Warning: /root/.stash is owned by UID ${actual_uid}, but PUID=${PUID}."
-        echo "Stash may fail with 'permission denied'. Either set PUID=${actual_uid} (and PGID to match),"
-        echo "or chown the host bind mount to ${PUID}:${PGID} before starting the container."
-    fi
-
     exec gosu stash "$@"
 fi
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,12 +83,6 @@ Installing dependencies...
     pip install -r $output_file
 fi
 
-PUID=${PUID:-911}
-PGID=${PGID:-911}
-if [ "$PUID" -eq 0 ] || [ "$PGID" -eq 0 ]; then
-    echo "Error: PUID/PGID cannot be 0" >&2
-    exit 1
-fi
 if [ -z "${1:-}" ]; then
     set -- "stash"
 fi
@@ -104,23 +98,18 @@ https://opencollective.com/stashapp
 
 ───────────────────────────────────────'
 echo '
-Changing to user provided UID & GID...
-'
-
-groupmod -o -g "$PGID" stash
-usermod -o -u "$PUID" stash
-echo '
-───────────────────────────────────────
-GID/UID
-───────────────────────────────────────'
-echo "
-UID:${PUID}
-GID:${PGID}"
-echo '
-───────────────────────────────────────'
-echo '
 Starting stash...
 
 ───────────────────────────────────────
 '
-exec gosu stash "$@"
+if [ -n "${PUID:-}" ] && [ -n "${PGID:-}" ]; then
+    if [ "$PUID" -eq 0 ] || [ "$PGID" -eq 0 ]; then
+        echo "Error: PUID/PGID cannot be 0" >&2
+        exit 1
+    fi
+    groupmod -o -g "$PGID" stash
+    usermod -o -u "$PUID" stash
+    echo "UID:${PUID} GID:${PGID}"
+    exec gosu stash "$@"
+fi
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,7 +102,15 @@ Starting stash...
 
 ───────────────────────────────────────
 '
-if [ -n "${PUID:-}" ] && [ -n "${PGID:-}" ]; then
+if [ -n "${PUID:-}" ] || [ -n "${PGID:-}" ]; then
+    if [ -z "${PUID:-}" ] || [ -z "${PGID:-}" ]; then
+        echo "Error: PUID and PGID must both be set" >&2
+        exit 1
+    fi
+    if ! [[ "$PUID" =~ ^[0-9]+$ ]] || ! [[ "$PGID" =~ ^[0-9]+$ ]]; then
+        echo "Error: PUID and PGID must be positive integers" >&2
+        exit 1
+    fi
     if [ "$PUID" -eq 0 ] || [ "$PGID" -eq 0 ]; then
         echo "Error: PUID/PGID cannot be 0" >&2
         exit 1


### PR DESCRIPTION
## Summary

- PUID/PGID previously defaulted to 911 and always triggered a `gosu` privilege drop, breaking containers where bind-mounted volumes are owned by a different UID (e.g. TrueNAS uses 568)
- Since this image is a root-running drop-in replacement, PUID/PGID now only take effect when explicitly set in the environment
- When unset, stash runs as root (original behaviour)

Fixes #78

## Test plan

- [x] Start container without PUID/PGID set — confirm stash runs as root and config is accessible
- [x] Start container with PUID/PGID matching volume ownership — confirm stash runs as the specified user
- [x] Start container with PUID/PGID not matching volume ownership — confirm permission denied (expected, user misconfiguration)
- [x] Start container with PUID=0 or PGID=0 — confirm error and exit