### PR TITLE
Add UID-mismatch warning and clarify PUID/PGID permission requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ services:
 
 Ensure host permissions are correct for the mounted volumes.
 
+If you set `PUID`/`PGID`, they must match the UID/GID that owns the host bind mounts — otherwise the in-container `stash` user can't read/write its config and Stash fails with `permission denied` on `config.yml`. Typical host UIDs: TrueNAS Scale apps (568), Unraid (99), Synology (1024), most Linux desktops/servers (1000). The entrypoint warns at startup if PUID and the bind-mount owner don't line up.
+
 **GPU not detected**
 * NVIDIA: driver + runtime present? (`nvidia-smi` on host)
 * Intel/AMD: is `/dev/dri` mapped and readable?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -118,6 +118,15 @@ if [ -n "${PUID:-}" ] || [ -n "${PGID:-}" ]; then
     groupmod -o -g "$PGID" stash
     usermod -o -u "$PUID" stash
     echo "UID:${PUID} GID:${PGID}"
+
+    # Warn if PUID doesn't match the actual owner of the config dir
+    actual_uid=$(stat -c '%u' /root/.stash 2>/dev/null || echo "")
+    if [ -n "$actual_uid" ] && [ "$actual_uid" != "$PUID" ]; then
+        echo "Warning: /root/.stash is owned by UID ${actual_uid}, but PUID=${PUID}."
+        echo "Stash may fail with 'permission denied'. Either set PUID=${actual_uid} (and PGID to match),"
+        echo "or chown the host bind mount to ${PUID}:${PGID} before starting the container."
+    fi
+
     exec gosu stash "$@"
 fi
 exec "$@"


### PR DESCRIPTION
Help diagnose permission failures by warning at startup if the configured PUID doesn't match the host bind-mount owner. Update README to explain the principle across platforms (TrueNAS, Unraid, Synology, desktop Linux).

Fixes #78 - prevents silent permission denied errors when PUID/PGID are set but don't align with host ownership.